### PR TITLE
Use pictures to represent a blog post on the Art page

### DIFF
--- a/_layouts/art.html
+++ b/_layouts/art.html
@@ -1,0 +1,20 @@
+---
+layout: page
+---
+<div class="home">
+  {%- if site.posts.size > 0 -%}
+    <ul class="post-list">
+      {%- for post in site.categories.art_post -%}
+      <li>
+        {%- assign date_format = site.date_format | default: "%b %-d, %Y" -%}
+        <span class="post-meta">{{ post.date | date: date_format }}</span>
+        <h3>
+          <a class="post-link" href="{{ post.url | relative_url }}">
+            <img src={{post.image | relative }} />
+          </a>
+        </h3>
+      </li>
+      {%- endfor -%}
+    </ul>
+  {%- endif -%}
+</div>

--- a/_posts/art/2021-01-30-hello-world.md
+++ b/_posts/art/2021-01-30-hello-world.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: Hello World!
+category: art_post
+image: /images/100_qoute.png
+---
+Placeholder for content

--- a/art.md
+++ b/art.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: art
 title: Art
 ---
 


### PR DESCRIPTION
This pull request is responding to the request for guidance in StackOverflow question.
https://stackoverflow.com/questions/66552789/change-link-to-blog-post-from-text-to-an-image-link

I did not know how to capture this PR in an answer to a SO question.  I hope the below helps you level up with Jekyll.

Here is my proposed solution for your request for making a picture represent a blog post on the Art page.  I hope it is helpful for your needs.

- I have created a new Jekyll layout, `art.html`.  
- The layout expects art posts (i.e. Markdown files for the Art page) to have a `image` Jekyll Front Matter attribute.  See `_posts/art/2021-01-30-hello-world.md` for an example. 
- Each art post's timestamp is determined by the filename (a default behavior in Jekyll)
- I created a new subdirectory `_posts/art/` top help separate the Art page posts from the Blog page posts.   The separation mechanism is the `{%- for post in site.categories.art_post -%}` in the new `art.html` layout.  This mechanism is [Jekyll catagories](https://jekyllrb.com/docs/posts/#categories).
- I used an existing picture in the `images` directory for the example Art post.

Here is a snapshot of my PR code running with `bundle exec jekyll s` on my MacOS laptop.  The snapshot has a URL of http://localhost:4000/art.html
![image](https://user-images.githubusercontent.com/31117513/112246767-2a837600-8c21-11eb-87f1-fa8fc591b15e.png)

